### PR TITLE
Add automatic update function

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -4,7 +4,7 @@ $(function(){
     var image = message.image.url ? `<img src= ${ message.image.url }>` : "";
 
     var html = `<div class='message'>
-                  <section data-author=${message.user_name} data-create-at=${message.created_at} data-id=${message.id}>
+                  <section data-id=${message.id}>
                     <div class='message__upper-info'>
                       <div class='message__upper-info__talker'>
                         ${message.user_name}
@@ -56,22 +56,22 @@ var buildMessageHTML = function(message) {
   var image = message.image.url ? `<img src= ${ message.image.url }>` : "";
 
       //data-idが反映されるようにしている
-      var html = '<div class="message" data-id=' + message.id + '>' +
-        '<div class="upper-message">' +
-          '<div class="upper-message__user-name">' +
-            message.user_name +
-          '</div>' +
-          '<div class="upper-message__date">' +
-            message.created_at +
-          '</div>' +
-        '</div>' +
-        '<div class="lower-message">' +
-          '<p class="lower-message__content">' +
-            message.content +
-          '</p>' +
-          '<img src="' + message.image.url + '" class="lower-message__image" >' +
-        '</div>' +
-      '</div>'
+      var html = `<div class="message" data-id='message.id'>
+                    <div class="upper-message">
+                      <div class="upper-message__user-name">
+                        message.user_name
+                      </div>
+                      <div class="upper-message__date">
+                        message.created_at
+                      </div>
+                    </div>
+                    <div class="lower-message">'
+                      <p class="lower-message__content">
+                         message.content
+                       </p>
+                      <img src="' + message.image.url + '" class="lower-message__image" >
+                    </div>
+                  </div>`
     return html;
   };
 

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -39,8 +39,8 @@ $(function(){
     .done(function(data){
       var html = buildHTML(data);
       $('.messages').append(html)
-      $('.new_message__box').val('')
-      $('.hidden').val('')
+      $('.new_message__box').reset()
+      $('.hidden').reset()
       $('.messages').animate({scrollTop: $('.messages')[0].scrollHeight}, 'fast');
     })
     .fail(function(){

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -39,8 +39,7 @@ $(function(){
     .done(function(data){
       var html = buildHTML(data);
       $('.messages').append(html);
-      $('.new_message__box').val("")
-      $('.hidden').val("")
+      $("form")[0].reset();
       $('.messages').animate({scrollTop: $('.messages')[0].scrollHeight}, 'fast');
     })
     .fail(function(){

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -38,9 +38,9 @@ $(function(){
     })
     .done(function(data){
       var html = buildHTML(data);
-      $('.messages').append(html)
-      $('.new_message__box').reset()
-      $('.hidden').reset()
+      $('.messages').append(html);
+      $('.new_message__box').val("")
+      $('.hidden').val("")
       $('.messages').animate({scrollTop: $('.messages')[0].scrollHeight}, 'fast');
     })
     .fail(function(){
@@ -52,7 +52,9 @@ $(function(){
   })
 
 var buildMessageHTML = function(message) {
-    if (message.content && message.image.url) {
+  var content = message.content ? `${ message.content }` : "";
+  var image = message.image.url ? `<img src= ${ message.image.url }>` : "";
+
       //data-idが反映されるようにしている
       var html = '<div class="message" data-id=' + message.id + '>' +
         '<div class="upper-message">' +
@@ -70,39 +72,6 @@ var buildMessageHTML = function(message) {
           '<img src="' + message.image.url + '" class="lower-message__image" >' +
         '</div>' +
       '</div>'
-    } else if (message.content) {
-      //同様に、data-idが反映されるようにしている
-      var html = '<div class="message" data-id=' + message.id + '>' +
-        '<div class="upper-message">' +
-          '<div class="upper-message__user-name">' +
-            message.user_name +
-          '</div>' +
-          '<div class="upper-message__date">' +
-            message.created_at +
-          '</div>' +
-        '</div>' +
-        '<div class="lower-message">' +
-          '<p class="lower-message__content">' +
-            message.content +
-          '</p>' +
-        '</div>' +
-      '</div>'
-    } else if (message.image.url) {
-      //同様に、data-idが反映されるようにしている
-      var html = '<div class="message" data-id=' + message.id + '>' +
-        '<div class="upper-message">' +
-          '<div class="upper-message__user-name">' +
-            message.user_name +
-          '</div>' +
-          '<div class="upper-message__date">' +
-            message.created_at +
-          '</div>' +
-        '</div>' +
-        '<div class="lower-message">' +
-          '<img src="' + message.image.url + '" class="lower-message__image" >' +
-        '</div>' +
-      '</div>'
-    };
     return html;
   };
 

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,28 +1,28 @@
 $(function(){
-    function buildHTML(message){
-     var content = message.content ? `${ message.content }` : "";
-     var image = message.image ? `<img src= ${ message.image }>` : "";
+  function buildHTML(message){
+    var content = message.content ? `${ message.content }` : "";
+    var image = message.image.url ? `<img src= ${ message.image.url }>` : "";
+
     var html = `<div class='message'>
-                  <div class='message__upper-info'>
-                    <div class='message__upper-info__talker'>
-                      ${message.user_name}
+                  <section data-author=${message.user_name} data-create-at=${message.created_at} data-id=${message.id}>
+                    <div class='message__upper-info'>
+                      <div class='message__upper-info__talker'>
+                        ${message.user_name}
+                      </div>
+                    <div class='message__upper-info__date'>
+                      ${message.created_at}
                     </div>
-                  <div class='message__upper-info__date'>
-                    ${message.date}
                   </div>
-                </div>
-                <div class='message__text'>
-                  <p class='lower-message__content'>
-                    ${content}
-                  </p>
-                  <p class='lower-message__image'>
-                    ${image}
-                  </p>
+                  <div class='message__text'>
+                    <p class='lower-message__content'>
+                      ${content}
+                    </p>
+                    <p class='lower-message__image'>
+                      ${image}
+                    </p>
+                  </section>
                 </div>`
     return html;
-  }
-  function scroll() {
-    $('.messages').animate({scrollTop: $('.messages')[0].scrollHeight}, 'last');
   }
   $('#new_message').on('submit', function(e){
     e.preventDefault();
@@ -40,7 +40,8 @@ $(function(){
       var html = buildHTML(data);
       $('.messages').append(html)
       $('.new_message__box').val('')
-      scroll()
+      $('.hidden').val('')
+      $('.messages').animate({scrollTop: $('.messages')[0].scrollHeight}, 'fast');
     })
     .fail(function(){
       alert('error');
@@ -49,4 +50,95 @@ $(function(){
       $(".form__submit").removeAttr("disabled");
     })
   })
-})
+
+var buildMessageHTML = function(message) {
+    if (message.content && message.image.url) {
+      //data-idが反映されるようにしている
+      var html = '<div class="message" data-id=' + message.id + '>' +
+        '<div class="upper-message">' +
+          '<div class="upper-message__user-name">' +
+            message.user_name +
+          '</div>' +
+          '<div class="upper-message__date">' +
+            message.created_at +
+          '</div>' +
+        '</div>' +
+        '<div class="lower-message">' +
+          '<p class="lower-message__content">' +
+            message.content +
+          '</p>' +
+          '<img src="' + message.image.url + '" class="lower-message__image" >' +
+        '</div>' +
+      '</div>'
+    } else if (message.content) {
+      //同様に、data-idが反映されるようにしている
+      var html = '<div class="message" data-id=' + message.id + '>' +
+        '<div class="upper-message">' +
+          '<div class="upper-message__user-name">' +
+            message.user_name +
+          '</div>' +
+          '<div class="upper-message__date">' +
+            message.created_at +
+          '</div>' +
+        '</div>' +
+        '<div class="lower-message">' +
+          '<p class="lower-message__content">' +
+            message.content +
+          '</p>' +
+        '</div>' +
+      '</div>'
+    } else if (message.image.url) {
+      //同様に、data-idが反映されるようにしている
+      var html = '<div class="message" data-id=' + message.id + '>' +
+        '<div class="upper-message">' +
+          '<div class="upper-message__user-name">' +
+            message.user_name +
+          '</div>' +
+          '<div class="upper-message__date">' +
+            message.created_at +
+          '</div>' +
+        '</div>' +
+        '<div class="lower-message">' +
+          '<img src="' + message.image.url + '" class="lower-message__image" >' +
+        '</div>' +
+      '</div>'
+    };
+    return html;
+  };
+
+  var reloadMessages = function() {
+    //カスタムデータ属性を利用し、ブラザに表示されている最新メッセージのidを取得
+    last_message_id = $("section:last").data("id");
+    var url = location.href.replace('/messages','')+'/api/messages';
+      $.ajax({
+      //ルーティングで設定した通りのURLを指定
+      url: url,
+      //ルーティングで設定した通りhttpメソッドをgetに指定
+      type: 'get',
+      dataType: 'json',
+      //dataオプションでリクエストに値を含める
+      data: {id: last_message_id}
+    })
+    .done(function(messages) {
+      //追加するHTMLの入れ物を作る
+      var insertHTML = '';
+      //配列messagesの中身一つ一つを取り出し、HTMLに変換したものを入れ物に足し合わせる
+      messages.forEach(function(message) {
+        if (message.id > last_message_id) {
+          insertHTML += buildHTML(message);
+        }
+      });
+      //メッセージが入ったHTMLを取得
+      $('.messages').append(insertHTML);
+      $('.messages').animate({scrollTop: $('.messages')[0].scrollHeight}, 'fast');
+      //メッセージを追加
+    })
+    .fail(function() {
+      alert('error');
+    });
+  };
+  setInterval(reloadMessages, 5000);
+});
+
+
+

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -124,9 +124,7 @@ var buildMessageHTML = function(message) {
       var insertHTML = '';
       //配列messagesの中身一つ一つを取り出し、HTMLに変換したものを入れ物に足し合わせる
       messages.forEach(function(message) {
-        if (message.id > last_message_id) {
-          insertHTML += buildHTML(message);
-        }
+        insertHTML += buildHTML(message);
       });
       //メッセージが入ったHTMLを取得
       $('.messages').append(insertHTML);

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,8 +1,9 @@
 class Api::MessagesController < ApplicationController
   def index
+    @group = Group.find(params[:group_id])
     respond_to do |format|
       format.html
-      format.json { @new_messages = Message.where('id > ?', params[:id]) }
+      format.json { @new_messages =  @group.messages.where('id > ?', params[:id]) }
       # json形式でアクセスがあった場合は、params[:message][:id]よりも大きいidがないかMessageから検索して、@new_messageに代入する
     end
   end

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,10 @@
+class Api::MessagesController < ApplicationController
+
+  def index
+    @messages = Message.all
+    respond_to do |format|
+      format.html
+      format.json { @new_message = Message.where('id > ?', params[:message][:id]) } # json形式でアクセスがあった場合は、params[:message][:id]よりも大きいidがないかMessageから検索して、@new_messageに代入する
+    end
+  end
+end

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,10 +1,9 @@
 class Api::MessagesController < ApplicationController
-
   def index
-    @messages = Message.all
     respond_to do |format|
       format.html
-      format.json { @new_message = Message.where('id > ?', params[:message][:id]) } # json形式でアクセスがあった場合は、params[:message][:id]よりも大きいidがないかMessageから検索して、@new_messageに代入する
+      format.json { @new_messages = Message.where('id > ?', params[:id]) }
+      # json形式でアクセスがあった場合は、params[:message][:id]よりも大きいidがないかMessageから検索して、@new_messageに代入する
     end
   end
 end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @new_messages do |message|
+  json.content message.content
+  json.image message.image
+  json.created_at message.created_at.strftime("%Y/%m/%d %H:%M")
+  json.user_name message.user.name
+  json.id message.id
+end

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,5 +1,5 @@
 .message
-  %section{ data: { id: message.id, author: message.user.name, create_at: message.created_at.strftime("%Y/%m/%d")} }
+  %section{ data: { id: message.id } }
     .message__upper-info
       .message__upper-info__talker
         = message.user.name

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,5 @@
 .message
+%section{ data: { id: message.id, author: message.user.name, create_at: message.created_at.strftime("%Y/%m/%d")} }
   .message__upper-info
     .message__upper-info__talker
       = message.user.name

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,12 +1,12 @@
 .message
-%section{ data: { id: message.id, author: message.user.name, create_at: message.created_at.strftime("%Y/%m/%d")} }
-  .message__upper-info
-    .message__upper-info__talker
-      = message.user.name
-    .message__upper-info__date
-      = message.created_at.strftime("%Y/%m/%d %H:%M")
-  .message__text
-    - if message.content.present?
-      %p.lower-message__content
-        = message.content
-    = image_tag message.image.url, class: 'lower-message__image' if message.image.present?
+  %section{ data: { id: message.id, author: message.user.name, create_at: message.created_at.strftime("%Y/%m/%d")} }
+    .message__upper-info
+      .message__upper-info__talker
+        = message.user.name
+      .message__upper-info__date
+        = message.created_at.strftime("%Y/%m/%d %H:%M")
+    .message__text
+      - if message.content.present?
+        %p.lower-message__content
+          = message.content
+      = image_tag message.image.url, class: 'lower-message__image' if message.image.present?

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,5 +1,5 @@
-json.id      @message.id
-json.content @message.content
-json.date    @message.created_at.strftime("%Y/%m/%d %H:%M")
+json.(@message, :content, :image)
+json.created_at @message.created_at.strftime("%Y/%m/%d %H:%M")
 json.user_name @message.user.name
-json.image   @message.image.url
+#idもデータとして渡す
+json.id @message.id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,9 @@ Rails.application.routes.draw do
   resources :users, only: [:index, :edit, :update]
   resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
+
+    namespace :api do
+      resources :messages, only: :index, defaults: { format: 'json' }
+    end
   end
 end


### PR DESCRIPTION
# What
自動更新機能の実装

# Why
メッセージ画面が自動で更新されることで、自分以外のユーザーが送信したメッセージも更新時に表示されるようにしなければならない為

# Do
- 2画面同時に開き、適切に自動更新されるか確認
- 自動更新時に、画面が最下部までスクロールされる
- テキスト/画像ともに自動更新される
- 関数名は処理の内容を過不足なく表現できるような名前になっている
- 変数名はデータの内容を過不足なく表現できるような名前になっている
- binding.pryやconsole.logなどのデバッグ用の記載は消去してある
- コードのインデントは適切に取ってある
- 自動更新の様子を撮影したgifが、プルリクエストに添付されている
- プルリクエストが正しく作られている
- プルリクエストにWhy/Whatを記載
- プルリクエストのWhy/Whatにマークダウンが適用

〈gif〉
https://gyazo.com/69dd1909ed369ce604669f7cc231d3b6
https://gyazo.com/a8eeb3ed2f7561ed85984eba8dd99d1c